### PR TITLE
Increase browser timeout from 10 secs to 100 secs

### DIFF
--- a/karma/shared.config.js
+++ b/karma/shared.config.js
@@ -47,6 +47,8 @@ exports.baseConfig = function(karma) {
 				flags: ['--no-sandbox'],
 			},
 		},
+
+		browserNoActivityTimeout: 100000,
 	};
 };
 


### PR DESCRIPTION
This should reduce the number of total failures we've been seeing in firefox. Just giving it more time... seems to work?

resolves https://renovo.myjetbrains.com/youtrack/issue/INF-188